### PR TITLE
Add ECCV 2026 paper to news and publications

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,3 +1,5 @@
+- date: "Jun 2026"
+  content: "Our paper <i>What CLIP Knows but Cannot Say: Recovering Negation from Frozen Intermediate Features</i> has been accepted to <b>ECCV 2026</b>!"
 - date: "Mar 2025"
   content: "Our paper <i>SKALD</i> has been accepted to <b>ICCV 2025</b>!"
 - date: "Feb 2025"

--- a/_includes/publications.md
+++ b/_includes/publications.md
@@ -4,7 +4,7 @@
 <li>
 <div class="pub-row">
   <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
-    <img src="/assets/img/eccv.jpg" class="teaser img-fluid z-depth-1">
+    <img src="/assets/img/tbd.svg" class="teaser img-fluid z-depth-1">
     <abbr class="badge">ECCV</abbr>
   </div>
   <div class="col-sm-9" style="position: relative;padding-right: 15px;padding-left: 20px;">

--- a/_includes/publications.md
+++ b/_includes/publications.md
@@ -4,6 +4,22 @@
 <li>
 <div class="pub-row">
   <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
+    <img src="/assets/img/eccv.jpg" class="teaser img-fluid z-depth-1">
+    <abbr class="badge">ECCV</abbr>
+  </div>
+  <div class="col-sm-9" style="position: relative;padding-right: 15px;padding-left: 20px;">
+    <div class="title">What CLIP Knows but Cannot Say: Recovering Negation from Frozen Intermediate Features</div>
+    <div class="author"><strong>Chen-Yi Lu</strong>, Yueh-Shao Chen, Somali Chaterji</div>
+    <div class="periodical"><em><strong>European Conference on Computer Vision (ECCV)</strong>, 2026.</em></div>
+    <div class="links">
+      <a href="#" class="btn btn-sm z-depth-0" role="button" target="_blank" style="font-size:12px;">PDF (TBD)</a>
+    </div>
+  </div>
+</div>
+</li>
+<li>
+<div class="pub-row">
+  <div class="col-sm-3 abbr" style="position: relative;padding-right: 15px;padding-left: 15px;">
     <img src="/assets/img/iccv.png" class="teaser img-fluid z-depth-1">
     <abbr class="badge">ICCV</abbr>
   </div>

--- a/assets/img/tbd.svg
+++ b/assets/img/tbd.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 150" width="200" height="150" role="img" aria-label="Teaser coming soon">
+  <rect width="200" height="150" fill="#e9ecef"/>
+  <rect x="4" y="4" width="192" height="142" fill="none" stroke="#adb5bd" stroke-width="2" stroke-dasharray="8 6"/>
+  <text x="100" y="78" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700" fill="#868e96" text-anchor="middle">TBD</text>
+  <text x="100" y="104" font-family="Arial, Helvetica, sans-serif" font-size="13" fill="#868e96" text-anchor="middle">teaser coming soon</text>
+</svg>


### PR DESCRIPTION
Add news item and publication entry for 'What CLIP Knows but Cannot Say:
Recovering Negation from Frozen Intermediate Features' accepted to ECCV 2026.
Thumbnail and links are placeholders (TBD).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WgsGi1k97LxPFjFxbzBvwY